### PR TITLE
Fix cloth-config dependency

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,7 +35,8 @@
     "fabricloader": ">=0.14.21",
     "minecraft": "~1.20",
     "java": ">=17",
-    "fabric-api": "*"
+    "fabric-api": "*",
+    "cloth-config": "*"
   },
   "suggests": {
     "another-mod": "*"


### PR DESCRIPTION
Minecraft no longer crashes without any message if there is no cloth-config installed.
(i hope i did that the right way)